### PR TITLE
Check sensitive fields case-insensitive

### DIFF
--- a/config/request-response-log.php
+++ b/config/request-response-log.php
@@ -6,7 +6,7 @@ return [
     'prune_after_days' => 30,
 
     'security' => [
-        // For security reason we should not log sensitive fields.
+        // For security reason we should not log sensitive fields. These fields will be checked case-insensitive.
         'sensitive_fields' => [
             'password',
             'access_token',
@@ -22,6 +22,8 @@ return [
             'php-auth-digest',
         ],
 
+        // For security reason we should not log sensitive fields for certain vendors. These fields will be checked
+        // case-insensitive.
         'sensitive_fields_per_vendor' => [],
     ],
 

--- a/src/Helpers/Sanitizer.php
+++ b/src/Helpers/Sanitizer.php
@@ -3,6 +3,7 @@
 namespace Goedemiddag\RequestResponseLog\Helpers;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use JsonException;
 
 class Sanitizer
@@ -41,8 +42,10 @@ class Sanitizer
         $sensitiveFieldsPerVendor = Arr::get(config('request-response-log.security.sensitive_fields_per_vendor', []), $vendor, []);
 
         foreach ($array as $key => $value) {
-            $hasGenericSensitiveKey = in_array($key, $sensitiveFields, true);
-            $hasVendorSensitiveKey = in_array($key, $sensitiveFieldsPerVendor, true);
+            $searchKey = Str::lower($key);
+
+            $hasGenericSensitiveKey = in_array($searchKey, $sensitiveFields, true);
+            $hasVendorSensitiveKey = in_array($searchKey, $sensitiveFieldsPerVendor, true);
 
             // When the key is sensitive, mask the value
             if ($hasGenericSensitiveKey || $hasVendorSensitiveKey) {

--- a/tests/Helpers/SanitizerTest.php
+++ b/tests/Helpers/SanitizerTest.php
@@ -12,13 +12,16 @@ class SanitizerTest extends TestCase
         $data = [
             'password' => 'secret',
             'hello' => 'world',
+            'Authorization' => 'Bearer my-secret-key',
         ];
 
         $sanitizedData = Sanitizer::filterSensitiveData($data);
 
         $this->assertArrayHasKey('password', $sanitizedData);
         $this->assertArrayHasKey('hello', $sanitizedData);
+        $this->assertArrayHasKey('Authorization', $sanitizedData);
         $this->assertSame('********', $sanitizedData['password']);
+        $this->assertSame('********', $sanitizedData['Authorization']);
         $this->assertSame('world', $sanitizedData['hello']);
     }
 


### PR DESCRIPTION
# Changes

- The sensitive fields were checked case-sensitive, which caused the `Authorization` header not being masked. This has changed to case-insensitive checks.
