### PR TITLE
Change return type of middleware to capture all different Laravel response types

### DIFF
--- a/src/Middleware/ApplicationRequestResponseLogger.php
+++ b/src/Middleware/ApplicationRequestResponseLogger.php
@@ -6,7 +6,7 @@ use Closure;
 use Goedemiddag\RequestResponseLog\Enums\RequestFlow;
 use Goedemiddag\RequestResponseLog\ManualRequestResponseLogger;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
+use Symfony\Component\HttpFoundation\Response;
 
 class ApplicationRequestResponseLogger
 {


### PR DESCRIPTION
# Changes

- Change return type of middleware to capture all different Laravel response types to prevent issues when those other response types are returned
