### PR TITLE
Add ability to retrieve request-identifier from context

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,19 @@ $schedule
     ->daily();
 ```
 
+## Request Identifier
+
+It is possible to provide a specific request identifier to the logger which helps you relate logs to each other. In 
+case you are using the middleware or the request middleware, you can use the Laravel Context to provide the `request-identifier`. 
+
+```php
+Context::add('request-identifier', 'your-identifier');
+```
+
+When using the application middleware, make sure to set the request identifier **before** the middleware is called.
+
+For more information on how to use this, see the `ApplicationRequestResponseLoggerTest` for an example.
+
 ## Contributing
 
 Found a bug or want to add a new feature? Great! There are also many other ways to make meaningful contributions such 

--- a/src/Middleware/ApplicationRequestResponseLogger.php
+++ b/src/Middleware/ApplicationRequestResponseLogger.php
@@ -6,6 +6,7 @@ use Closure;
 use Goedemiddag\RequestResponseLog\Enums\RequestFlow;
 use Goedemiddag\RequestResponseLog\ManualRequestResponseLogger;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Context;
 use Symfony\Component\HttpFoundation\Response;
 
 class ApplicationRequestResponseLogger
@@ -16,6 +17,7 @@ class ApplicationRequestResponseLogger
             vendor: $vendor,
             request: $request,
             flow: RequestFlow::Incoming,
+            requestIdentifier: Context::get('request-identifier'),
         );
 
         $response = $next($request);

--- a/src/RequestResponseLogger.php
+++ b/src/RequestResponseLogger.php
@@ -4,6 +4,7 @@ namespace Goedemiddag\RequestResponseLog;
 
 use Goedemiddag\RequestResponseLog\Factories\PsrRequestLogFactory;
 use Goedemiddag\RequestResponseLog\Factories\PsrResponseLogFactory;
+use Illuminate\Support\Facades\Context;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -16,6 +17,7 @@ class RequestResponseLogger
                 $requestLogFactory = new PsrRequestLogFactory(
                     request: $request,
                     vendor: $vendor,
+                    requestIdentifier: Context::get('request-identifier'),
                 );
 
                 $requestLog = $requestLogFactory->build();

--- a/tests/Middleware/ApplicationRequestResponseLoggerTest.php
+++ b/tests/Middleware/ApplicationRequestResponseLoggerTest.php
@@ -6,6 +6,7 @@ use Goedemiddag\RequestResponseLog\Middleware\ApplicationRequestResponseLogger;
 use Goedemiddag\RequestResponseLog\Models\RequestLog;
 use Goedemiddag\RequestResponseLog\Tests\TestCase;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Context;
 
 class ApplicationRequestResponseLoggerTest extends TestCase
 {
@@ -16,6 +17,8 @@ class ApplicationRequestResponseLoggerTest extends TestCase
             method: 'POST',
             content: json_encode(['logged' => 'success']),
         );
+
+        Context::add('request-identifier', 'test-request-identifier');
 
         $next = function () {
             return response('This is the response', 200);
@@ -33,6 +36,7 @@ class ApplicationRequestResponseLoggerTest extends TestCase
             'path' => '/app-middleware',
             'query_parameters' => json_encode(['app' => '1']),
             'body' => json_encode(['logged' => 'success']),
+            'request_identifier' => 'test-request-identifier',
         ]);
     }
 }


### PR DESCRIPTION
# Changes

When using the middleware, it was not possible to provide the request identifier. This PR adds the ability to retrieve request-identifier from Laravel's Context and provides documentation about the request identifier as that was missing at all.
