### PR TITLE
Remove unique constraint from request_identifier

### DIFF
--- a/database/migrations/2025_03_23_100000_request_identifier_not_unique.php
+++ b/database/migrations/2025_03_23_100000_request_identifier_not_unique.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        $requestLogTable = config('request-response-log.database.request_log_table');
+        if (empty($requestLogTable)) {
+            throw new RuntimeException('Request log table name is not set in the configuration.');
+        }
+
+        Schema::table($requestLogTable, function (Blueprint $table) {
+            $table->dropUnique(['request_identifier']);
+        });
+    }
+};


### PR DESCRIPTION
# Changes

## Removed

- When the `request_identifier` is used to identity the request made to the application, it could be used multiple times. The unique constraint of the `request_identifier` prevented that, that's why it is removed.
